### PR TITLE
Fix editor overflow and add copy button

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -142,7 +142,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
       </div>
 
       {/* Editor */}
-      <div className="flex-1 flex relative">
+      <div className="flex-1 flex relative overflow-auto">
         {/* Line numbers */}
         <div className="w-12 bg-editor-gutter border-r border-editor-border flex flex-col text-right py-3 select-none">
           {lineNumbers.map((lineNum) => (
@@ -156,7 +156,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
         </div>
 
         {/* Code area */}
-        <div className="flex-1 relative overflow-hidden">
+        <div className="flex-1 relative">
           <textarea
             ref={textareaRef}
             value={value}

--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { Monitor, RefreshCw, Maximize2 } from 'lucide-react';
+import { Monitor, RefreshCw, Maximize2, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface LivePreviewProps {
@@ -173,6 +173,10 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit }) => {
     }
   };
 
+  const copyCode = () => {
+    navigator.clipboard.writeText(code);
+  };
+
   return (
     <div className="h-full flex flex-col bg-preview-bg">
       {/* Header */}
@@ -192,6 +196,14 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit }) => {
             className="h-7 px-2 text-gray-600 hover:text-gray-900"
           >
             <RefreshCw className="w-3 h-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={copyCode}
+            className="h-7 px-2 text-gray-600 hover:text-gray-900"
+          >
+            <Copy className="w-3 h-3" />
           </Button>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
- allow scrolling the code editor
- enable copying code from live preview

## Testing
- `npm run lint` *(fails: no-cond-assign, no-empty-object-type, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877fa4262c483249041020afd473b51