### PR TITLE
Implement preview-to-code line sync

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -12,9 +12,10 @@ interface CodeEditorProps {
   value: string;
   onChange: (value: string) => void;
   onRun: () => void;
+  highlightLine?: number;
 }
 
-const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
+const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun, highlightLine }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [lineNumbers, setLineNumbers] = useState<number[]>([1]);
 
@@ -22,6 +23,22 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
     const lines = value.split('\n').length;
     setLineNumbers(Array.from({ length: lines }, (_, i) => i + 1));
   }, [value]);
+
+  useEffect(() => {
+    if (!highlightLine || !textareaRef.current) return;
+    const lines = value.split('\n');
+    let index = 0;
+    for (let i = 0; i < highlightLine - 1 && i < lines.length; i++) {
+      index += lines[i].length + 1; // newline
+    }
+    const start = index;
+    const end = Math.min(index + (lines[highlightLine - 1]?.length || 0), value.length);
+    const textarea = textareaRef.current;
+    textarea.focus();
+    textarea.setSelectionRange(start, end);
+    const lineEl = document.getElementById(`line-${highlightLine}`);
+    lineEl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [highlightLine, value]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Tab') {
@@ -154,7 +171,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
           {lineNumbers.map((lineNum) => (
             <div
               key={lineNum}
-              className="text-xs text-text-muted font-mono leading-6 px-2"
+              id={`line-${lineNum}`}
+              className={`text-xs text-text-muted font-mono leading-6 px-2 ${highlightLine === lineNum ? 'bg-accent-primary/20' : ''}`}
             >
               {lineNum}
             </div>

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -65,6 +65,7 @@ const defaultCode = `<!DOCTYPE html>
 
 const SplitLayout: React.FC = () => {
   const [code, setCode] = useState(defaultCode);
+  const [highlightLine, setHighlightLine] = useState<number>();
 
   const handleCodeChange = useCallback((newCode: string) => {
     setCode(newCode);
@@ -79,6 +80,10 @@ const SplitLayout: React.FC = () => {
     setCode(current => current.replace(html, ''));
   }, []);
 
+  const handleElementSelect = useCallback((line: number) => {
+    setHighlightLine(line);
+  }, []);
+
   const handleRun = useCallback(() => {
     // Force refresh by updating code
     setCode(prev => prev);
@@ -88,11 +93,11 @@ const SplitLayout: React.FC = () => {
     <div className="h-screen bg-background text-foreground overflow-hidden">
       <ResizablePanelGroup direction="horizontal" className="h-full">
         <ResizablePanel defaultSize={50} minSize={20} className="overflow-y-auto">
-          <CodeEditor value={code} onChange={handleCodeChange} onRun={handleRun} />
+          <CodeEditor value={code} onChange={handleCodeChange} onRun={handleRun} highlightLine={highlightLine} />
         </ResizablePanel>
         <ResizableHandle withHandle className="bg-border" />
         <ResizablePanel minSize={20} className="overflow-y-auto">
-          <LivePreview code={code} onTextEdit={handleTextEdit} onElementDelete={handleElementDelete} />
+          <LivePreview code={code} onTextEdit={handleTextEdit} onElementDelete={handleElementDelete} onElementSelect={handleElementSelect} />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
## Summary
- allow clicking preview elements to highlight code line
- show highlight in editor and scroll to line

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3374c268832482a7d0b9f62d425b