### PR TITLE
Implement preview-to-code line sync

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -12,9 +12,10 @@ interface CodeEditorProps {
   value: string;
   onChange: (value: string) => void;
   onRun: () => void;
+  highlightLine?: number;
 }
 
-const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
+const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun, highlightLine }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [lineNumbers, setLineNumbers] = useState<number[]>([1]);
 
@@ -22,6 +23,22 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
     const lines = value.split('\n').length;
     setLineNumbers(Array.from({ length: lines }, (_, i) => i + 1));
   }, [value]);
+
+  useEffect(() => {
+    if (!highlightLine || !textareaRef.current) return;
+    const lines = value.split('\n');
+    let index = 0;
+    for (let i = 0; i < highlightLine - 1 && i < lines.length; i++) {
+      index += lines[i].length + 1; // newline
+    }
+    const start = index;
+    const end = Math.min(index + (lines[highlightLine - 1]?.length || 0), value.length);
+    const textarea = textareaRef.current;
+    textarea.focus();
+    textarea.setSelectionRange(start, end);
+    const lineEl = document.getElementById(`line-${highlightLine}`);
+    lineEl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [highlightLine, value]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Tab') {
@@ -154,7 +171,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ value, onChange, onRun }) => {
           {lineNumbers.map((lineNum) => (
             <div
               key={lineNum}
-              className="text-xs text-text-muted font-mono leading-6 px-2"
+              id={`line-${lineNum}`}
+              className={`text-xs text-text-muted font-mono leading-6 px-2 ${highlightLine === lineNum ? 'bg-accent-primary/20' : ''}`}
             >
               {lineNum}
             </div>

--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -6,9 +6,10 @@ interface LivePreviewProps {
   code: string;
   onTextEdit: (originalText: string, newText: string) => void;
   onElementDelete: (elementHtml: string) => void;
+  onElementSelect?: (lineNumber: number) => void;
 }
 
-const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDelete }) => {
+const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDelete, onElementSelect }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [deleteMode, setDeleteMode] = useState(false);
@@ -193,13 +194,45 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDe
       }
     };
 
+
+    const findLineNumber = (el: HTMLElement): number | null => {
+      const tag = el.tagName.toLowerCase();
+      const id = el.id ? `id="${el.id}"` : null;
+      const className = el.getAttribute('class');
+      const lines = code.split('\n');
+
+      const matchesLine = (line: string, str: string) => line.includes(str);
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (id && matchesLine(line, `<${tag}`) && matchesLine(line, id)) return i + 1;
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (className && matchesLine(line, `<${tag}`) && matchesLine(line, `class="${className}`)) return i + 1;
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes(`<${tag}`)) return i + 1;
+      }
+
+      return null;
+    };
+
     const handleSelect = (e: MouseEvent) => {
-      if (!deleteModeRef.current) return;
       if (!(e.target instanceof HTMLElement)) return;
       let target = e.target as HTMLElement;
       if (target.getAttribute('data-editable') === 'true') {
         target = target.parentElement as HTMLElement;
       }
+
+      const line = findLineNumber(target);
+      if (line && onElementSelect) {
+        onElementSelect(line);
+      }
+
+      if (!deleteModeRef.current) return;
       if (target.tagName !== 'DIV') return;
 
       e.preventDefault();

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -65,6 +65,7 @@ const defaultCode = `<!DOCTYPE html>
 
 const SplitLayout: React.FC = () => {
   const [code, setCode] = useState(defaultCode);
+  const [highlightLine, setHighlightLine] = useState<number>();
 
   const handleCodeChange = useCallback((newCode: string) => {
     setCode(newCode);
@@ -79,6 +80,10 @@ const SplitLayout: React.FC = () => {
     setCode(current => current.replace(html, ''));
   }, []);
 
+  const handleElementSelect = useCallback((line: number) => {
+    setHighlightLine(line);
+  }, []);
+
   const handleRun = useCallback(() => {
     // Force refresh by updating code
     setCode(prev => prev);
@@ -88,11 +93,11 @@ const SplitLayout: React.FC = () => {
     <div className="h-screen bg-background text-foreground overflow-hidden">
       <ResizablePanelGroup direction="horizontal" className="h-full">
         <ResizablePanel defaultSize={50} minSize={20} className="overflow-y-auto">
-          <CodeEditor value={code} onChange={handleCodeChange} onRun={handleRun} />
+          <CodeEditor value={code} onChange={handleCodeChange} onRun={handleRun} highlightLine={highlightLine} />
         </ResizablePanel>
         <ResizableHandle withHandle className="bg-border" />
         <ResizablePanel minSize={20} className="overflow-y-auto">
-          <LivePreview code={code} onTextEdit={handleTextEdit} onElementDelete={handleElementDelete} />
+          <LivePreview code={code} onTextEdit={handleTextEdit} onElementDelete={handleElementDelete} onElementSelect={handleElementSelect} />
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
## Summary
- allow clicking preview elements to highlight code line
- show highlight in editor and scroll to line
- connect `LivePreview` to `onElementSelect` callback

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3374c268832482a7d0b9f62d425b