### PR TITLE
Add inline formatting toolbar in LivePreview

### DIFF
--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -39,6 +39,49 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDe
   }, [code]);
 
   const enableInlineEditing = (doc: Document) => {
+    // Create a floating toolbar for text formatting
+    const toolbar = doc.createElement('div');
+    toolbar.style.position = 'absolute';
+    toolbar.style.display = 'none';
+    toolbar.style.background = '#fff';
+    toolbar.style.border = '1px solid #ccc';
+    toolbar.style.borderRadius = '4px';
+    toolbar.style.padding = '2px';
+    toolbar.style.boxShadow = '0 2px 6px rgba(0,0,0,0.15)';
+    toolbar.style.zIndex = '10000';
+    toolbar.style.fontFamily = 'system-ui, sans-serif';
+
+    const createBtn = (label: string, command: string) => {
+      const btn = doc.createElement('button');
+      btn.textContent = label;
+      btn.style.background = 'transparent';
+      btn.style.border = 'none';
+      btn.style.padding = '2px 4px';
+      btn.style.cursor = 'pointer';
+      btn.style.fontSize = '12px';
+      btn.onclick = (e) => {
+        e.preventDefault();
+        doc.execCommand(command);
+        hideToolbar();
+      };
+      return btn;
+    };
+
+    toolbar.appendChild(createBtn('B', 'bold'));
+    toolbar.appendChild(createBtn('I', 'italic'));
+    toolbar.appendChild(createBtn('U', 'underline'));
+
+    const showToolbar = (rect: DOMRect) => {
+      toolbar.style.left = `${rect.left + doc.documentElement.scrollLeft}px`;
+      toolbar.style.top = `${rect.top + doc.documentElement.scrollTop - toolbar.offsetHeight - 4}px`;
+      toolbar.style.display = 'flex';
+    };
+
+    const hideToolbar = () => {
+      toolbar.style.display = 'none';
+    };
+
+    doc.body.appendChild(toolbar);
     // Find all text nodes and make them editable
     const walker = doc.createTreeWalker(
       doc.body,
@@ -100,6 +143,21 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDe
           span.style.boxShadow = 'none';
         }
       });
+
+      const checkSelection = () => {
+        const sel = doc.getSelection();
+        if (!sel || sel.isCollapsed || !span.contains(sel.anchorNode)) {
+          hideToolbar();
+          return;
+        }
+        const range = sel.getRangeAt(0);
+        const rect = range.getBoundingClientRect();
+        showToolbar(rect);
+      };
+
+      span.addEventListener('mouseup', checkSelection);
+      span.addEventListener('keyup', checkSelection);
+      span.addEventListener('blur', hideToolbar);
 
       span.addEventListener('focus', () => {
         span.style.backgroundColor = 'rgba(59, 130, 246, 0.1)';


### PR DESCRIPTION
## Summary
- add floating toolbar for text styling in the preview
- show toolbar when selecting editable text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e89a1823083249bda383826b2cb6d