### PR TITLE
Fix code line highlight on preview click

### DIFF
--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -196,6 +196,16 @@ const LivePreview: React.FC<LivePreviewProps> = ({ code, onTextEdit, onElementDe
 
 
     const findLineNumber = (el: HTMLElement): number | null => {
+      const cleanClone = el.cloneNode(true) as HTMLElement;
+      cleanClone.querySelectorAll('[data-editable="true"]').forEach((span) => {
+        span.replaceWith(span.textContent || '');
+      });
+      const html = cleanClone.outerHTML.trim();
+      const index = code.indexOf(html);
+      if (index !== -1) {
+        return code.slice(0, index).split('\n').length;
+      }
+
       const tag = el.tagName.toLowerCase();
       const id = el.id ? `id="${el.id}"` : null;
       const className = el.getAttribute('class');

--- a/src/components/SplitLayout.tsx
+++ b/src/components/SplitLayout.tsx
@@ -81,7 +81,9 @@ const SplitLayout: React.FC = () => {
   }, []);
 
   const handleElementSelect = useCallback((line: number) => {
-    setHighlightLine(line);
+    // Reset first to allow re-selecting the same line
+    setHighlightLine(undefined);
+    setTimeout(() => setHighlightLine(line), 0);
   }, []);
 
   const handleRun = useCallback(() => {


### PR DESCRIPTION
## Summary
- sanitize element HTML before searching code for accurate line number
- ensure highlight resets when selecting the same element

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e8c8b0ba083249f0df401403c1554